### PR TITLE
Make `hash` follow the spec and add tests for messages

### DIFF
--- a/src/dataTypes.ts
+++ b/src/dataTypes.ts
@@ -1,0 +1,180 @@
+import * as TCP from 'net';
+
+import { MultiplicativeGroup } from './multiplicativeGroup';
+import { ENDIAN } from './constants';
+import BN from 'bn.js';
+
+import { concatUint8Array } from './utils';
+import { NotImplemented, ValueError, FailedToReadData } from './exceptions';
+
+// NOTE: a workaround type to make typing work with `createFixedIntClass`.
+abstract class BaseSerializable {
+  static deserialize(_: Uint8Array): BaseSerializable {
+    throw new NotImplemented(); // Make tsc happy
+  }
+  abstract serialize(): Uint8Array;
+}
+
+class BaseFixedInt extends BaseSerializable {
+  static size: number;
+  constructor(readonly value: number) {
+    super();
+  }
+  static deserialize(_: Uint8Array): BaseFixedInt {
+    throw new NotImplemented(); // Make tsc happy
+  }
+  serialize(): Uint8Array {
+    throw new NotImplemented(); // Make tsc happy
+  }
+}
+
+function numberToUint8Array(value: number, size?: number): Uint8Array {
+  return new Uint8Array(new BN(value).toArray(ENDIAN, size));
+}
+
+function uint8ArrayToNumber(a: Uint8Array): number {
+  // the max value of `number` type is `2**53 - 1`
+  if (a.length > 6) {
+    throw new ValueError();
+  }
+  return new BN(a).toNumber();
+}
+
+function createFixedIntClass(size: number): typeof BaseFixedInt {
+  class FixedIntClass extends BaseFixedInt {
+    static size: number = size;
+
+    constructor(readonly value: number) {
+      super(value);
+      if (value < 0 || value > 2 ** (size * 8) - 1) {
+        throw new ValueError(
+          `invalid value: value=${value}, maximum=${2 ** (size * 8) - 1}`
+        );
+      }
+    }
+
+    static deserialize(bytes: Uint8Array): FixedIntClass {
+      if (bytes.length !== size) {
+        throw new ValueError();
+      }
+      return new FixedIntClass(uint8ArrayToNumber(bytes));
+    }
+
+    serialize(): Uint8Array {
+      return numberToUint8Array(this.value, size);
+    }
+  }
+  return FixedIntClass;
+}
+
+/**
+ * Returns the average of two numbers.
+
+ * @param x - The first input number
+ * @param y - The second input number
+ * @returns The arithmetic mean of `x` and `y`
+ *
+ */
+const Byte = createFixedIntClass(1);
+const Short = createFixedIntClass(2);
+const Int = createFixedIntClass(4);
+
+class MPI implements BaseSerializable {
+  static lengthSize: number = 4;
+
+  constructor(readonly value: BN) {
+    if (value.isNeg()) {
+      throw new ValueError('expect non-negative value');
+    }
+  }
+
+  serialize(): Uint8Array {
+    const bytes = new Uint8Array(this.value.toArray(ENDIAN));
+    const lenBytes = numberToUint8Array(bytes.length, MPI.lengthSize);
+    return concatUint8Array(lenBytes, bytes);
+  }
+
+  static consume(bytes: Uint8Array): [MPI, Uint8Array] {
+    const len = uint8ArrayToNumber(bytes.slice(0, this.lengthSize));
+    if (bytes.length < this.lengthSize + len) {
+      throw new ValueError('`bytes` does not long enough for `len`');
+    }
+    const value = new BN(bytes.slice(this.lengthSize, this.lengthSize + len));
+    return [new MPI(value), bytes.slice(this.lengthSize + len)];
+  }
+
+  static deserialize(bytes: Uint8Array): MPI {
+    const [mpi, bytesRemaining] = this.consume(bytes);
+    if (bytesRemaining.length !== 0) {
+      throw new ValueError(
+        `bytes=${bytes} contains redundant bytes: bytesRemaining=${bytesRemaining}`
+      );
+    }
+    return mpi;
+  }
+
+  static fromMultiplicativeGroup(g: MultiplicativeGroup): MPI {
+    return new MPI(g.value);
+  }
+}
+
+class TLV extends BaseSerializable {
+  constructor(readonly type: BaseFixedInt, readonly value: Uint8Array) {
+    super();
+  }
+
+  static readFromSocket(socket: TCP.Socket): TLV {
+    const typeBytes = socket.read(Short.size);
+    if (
+      typeBytes === null ||
+      (typeBytes instanceof Buffer && typeBytes.length !== Short.size)
+    ) {
+      throw new FailedToReadData('failed to read type');
+    }
+    const type = Short.deserialize(typeBytes);
+    const lengthBytes = socket.read(Short.size);
+    if (
+      lengthBytes === null ||
+      (lengthBytes instanceof Buffer && lengthBytes.length !== Short.size)
+    ) {
+      throw new FailedToReadData('failed to read length');
+    }
+    const length = Short.deserialize(lengthBytes).value;
+    const valueBytes = socket.read(length);
+    if (
+      valueBytes === null ||
+      (valueBytes instanceof Buffer && valueBytes.length !== length)
+    ) {
+      throw new FailedToReadData('failed to read value');
+    }
+    const value = new Uint8Array(valueBytes);
+    return new TLV(type, value);
+  }
+
+  static deserialize(bytes: Uint8Array): TLV {
+    const typeSize = Short.size;
+    const lengthSize = Short.size;
+    const type = Short.deserialize(bytes.slice(0, typeSize));
+    const length = Short.deserialize(
+      bytes.slice(typeSize, typeSize + lengthSize)
+    );
+    const expectedTLVTotalSize = typeSize + lengthSize + length.value;
+    if (bytes.length < expectedTLVTotalSize) {
+      throw new ValueError('`bytes` does not long enough');
+    }
+    const value = bytes.slice(typeSize + lengthSize, expectedTLVTotalSize);
+    return new TLV(type, value);
+  }
+
+  serialize(): Uint8Array {
+    const typeBytes = this.type.serialize();
+    const lengthBytes = new Short(this.value.length).serialize();
+    const valueBytes = this.value;
+    return concatUint8Array(
+      concatUint8Array(typeBytes, lengthBytes),
+      valueBytes
+    );
+  }
+}
+
+export { BaseFixedInt, Byte, Short, Int, MPI, TLV };

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,12 +1,12 @@
 import BN from 'bn.js';
 import { sha256 } from 'js-sha256';
 
-import { ENDIAN } from './constants';
+import { MPI, concatUint8Array, Byte } from './msgs';
 
-export function sha256ToInt(intSize: number, ...args: BN[]): BN {
-  let res: number[] = [];
+export function smpHash(version: number, ...args: BN[]): BN {
+  let res = new Byte(version).serialize();
   for (const arg of args) {
-    res = res.concat(arg.toArray(ENDIAN, intSize));
+    res = concatUint8Array(res, new MPI(arg).serialize());
   }
   return new BN(sha256(res), 'hex');
 }

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -4,6 +4,14 @@ import { sha256 } from 'js-sha256';
 import { MPI, Byte } from './dataTypes';
 import { concatUint8Array } from './utils';
 
+/**
+ * SMP Hash function. SHA256 is used with `version` as the prefix.
+ * @param version This distinguishes calls to the hash function at different points in the protocol,
+ * to prevent Alice from replaying Bob's zero knowledge proofs or vice versa. It is serialized as a
+ * [[Byte]] type.
+ * @param args The arguments. Each of them is serialized as [[MPI]] type.
+ * @returns The hash result as an [[BN]] type integer.
+ */
 export function smpHash(version: number, ...args: BN[]): BN {
   let res = new Byte(version).serialize();
   for (const arg of args) {

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,7 +1,8 @@
 import BN from 'bn.js';
 import { sha256 } from 'js-sha256';
 
-import { MPI, concatUint8Array, Byte } from './msgs';
+import { MPI, Byte } from './dataTypes';
+import { concatUint8Array } from './utils';
 
 export function smpHash(version: number, ...args: BN[]): BN {
   let res = new Byte(version).serialize();

--- a/src/msgs.ts
+++ b/src/msgs.ts
@@ -55,6 +55,15 @@ function createFixedIntClass(size: number): typeof BaseFixedInt {
   class FixedIntClass extends BaseFixedInt {
     static size: number = size;
 
+    constructor(readonly value: number) {
+      super(value);
+      if (value < 0 || value > 2 ** (size * 8) - 1) {
+        throw new ValueError(
+          `invalid value: value=${value}, maximum=${2 ** (size * 8) - 1}`
+        );
+      }
+    }
+
     static deserialize(bytes: Uint8Array): FixedIntClass {
       if (bytes.length !== size) {
         throw new ValueError();
@@ -76,7 +85,11 @@ const Int = createFixedIntClass(4);
 class MPI implements BaseSerializable {
   static lengthSize: number = 4;
 
-  constructor(readonly value: BN) {}
+  constructor(readonly value: BN) {
+    if (value.isNeg()) {
+      throw new ValueError('expect non-negative value');
+    }
+  }
 
   serialize(): Uint8Array {
     const bytes = new Uint8Array(this.value.toArray(ENDIAN));

--- a/src/msgs.ts
+++ b/src/msgs.ts
@@ -1,184 +1,15 @@
-import * as TCP from 'net';
-
 import { MultiplicativeGroup } from './multiplicativeGroup';
 import {
   ProofDiscreteLog,
   ProofEqualDiscreteCoordinates,
   ProofEqualDiscreteLogs,
 } from './proofs';
-import { ENDIAN } from './constants';
 import BN from 'bn.js';
 
-import { NotImplemented, ValueError, FailedToReadData } from './exceptions';
+import { BaseFixedInt, Short, Int, MPI, TLV } from './dataTypes';
 
-// NOTE: a workaround type to make typing work with `createFixedIntClass`.
-abstract class BaseSerializable {
-  static deserialize(_: Uint8Array): BaseSerializable {
-    throw new NotImplemented(); // Make tsc happy
-  }
-  abstract serialize(): Uint8Array;
-}
-
-class BaseFixedInt extends BaseSerializable {
-  static size: number;
-  constructor(readonly value: number) {
-    super();
-  }
-  static deserialize(_: Uint8Array): BaseFixedInt {
-    throw new NotImplemented(); // Make tsc happy
-  }
-  serialize(): Uint8Array {
-    throw new NotImplemented(); // Make tsc happy
-  }
-}
-
-function numberToUint8Array(value: number, size?: number): Uint8Array {
-  return new Uint8Array(new BN(value).toArray(ENDIAN, size));
-}
-
-function uint8ArrayToNumber(a: Uint8Array): number {
-  // the max value of `number` type is `2**53 - 1`
-  if (a.length > 6) {
-    throw new ValueError();
-  }
-  return new BN(a).toNumber();
-}
-
-function concatUint8Array(a: Uint8Array, b: Uint8Array): Uint8Array {
-  let c = new Uint8Array(a.length + b.length);
-  c.set(a);
-  c.set(b, a.length);
-  return c;
-}
-
-function createFixedIntClass(size: number): typeof BaseFixedInt {
-  class FixedIntClass extends BaseFixedInt {
-    static size: number = size;
-
-    constructor(readonly value: number) {
-      super(value);
-      if (value < 0 || value > 2 ** (size * 8) - 1) {
-        throw new ValueError(
-          `invalid value: value=${value}, maximum=${2 ** (size * 8) - 1}`
-        );
-      }
-    }
-
-    static deserialize(bytes: Uint8Array): FixedIntClass {
-      if (bytes.length !== size) {
-        throw new ValueError();
-      }
-      return new FixedIntClass(uint8ArrayToNumber(bytes));
-    }
-
-    serialize(): Uint8Array {
-      return numberToUint8Array(this.value, size);
-    }
-  }
-  return FixedIntClass;
-}
-
-const Byte = createFixedIntClass(1);
-const Short = createFixedIntClass(2);
-const Int = createFixedIntClass(4);
-
-class MPI implements BaseSerializable {
-  static lengthSize: number = 4;
-
-  constructor(readonly value: BN) {
-    if (value.isNeg()) {
-      throw new ValueError('expect non-negative value');
-    }
-  }
-
-  serialize(): Uint8Array {
-    const bytes = new Uint8Array(this.value.toArray(ENDIAN));
-    const lenBytes = numberToUint8Array(bytes.length, MPI.lengthSize);
-    return concatUint8Array(lenBytes, bytes);
-  }
-
-  static consume(bytes: Uint8Array): [MPI, Uint8Array] {
-    const len = uint8ArrayToNumber(bytes.slice(0, this.lengthSize));
-    if (bytes.length < this.lengthSize + len) {
-      throw new ValueError('`bytes` does not long enough for `len`');
-    }
-    const value = new BN(bytes.slice(this.lengthSize, this.lengthSize + len));
-    return [new MPI(value), bytes.slice(this.lengthSize + len)];
-  }
-
-  static deserialize(bytes: Uint8Array): MPI {
-    const [mpi, bytesRemaining] = this.consume(bytes);
-    if (bytesRemaining.length !== 0) {
-      throw new ValueError(
-        `bytes=${bytes} contains redundant bytes: bytesRemaining=${bytesRemaining}`
-      );
-    }
-    return mpi;
-  }
-
-  static fromMultiplicativeGroup(g: MultiplicativeGroup): MPI {
-    return new MPI(g.value);
-  }
-}
-
-class TLV extends BaseSerializable {
-  constructor(readonly type: BaseFixedInt, readonly value: Uint8Array) {
-    super();
-  }
-
-  static readFromSocket(socket: TCP.Socket): TLV {
-    const typeBytes = socket.read(Short.size);
-    if (
-      typeBytes === null ||
-      (typeBytes instanceof Buffer && typeBytes.length !== Short.size)
-    ) {
-      throw new FailedToReadData('failed to read type');
-    }
-    const type = Short.deserialize(typeBytes);
-    const lengthBytes = socket.read(Short.size);
-    if (
-      lengthBytes === null ||
-      (lengthBytes instanceof Buffer && lengthBytes.length !== Short.size)
-    ) {
-      throw new FailedToReadData('failed to read length');
-    }
-    const length = Short.deserialize(lengthBytes).value;
-    const valueBytes = socket.read(length);
-    if (
-      valueBytes === null ||
-      (valueBytes instanceof Buffer && valueBytes.length !== length)
-    ) {
-      throw new FailedToReadData('failed to read value');
-    }
-    const value = new Uint8Array(valueBytes);
-    return new TLV(type, value);
-  }
-
-  static deserialize(bytes: Uint8Array): TLV {
-    const typeSize = Short.size;
-    const lengthSize = Short.size;
-    const type = Short.deserialize(bytes.slice(0, typeSize));
-    const length = Short.deserialize(
-      bytes.slice(typeSize, typeSize + lengthSize)
-    );
-    const expectedTLVTotalSize = typeSize + lengthSize + length.value;
-    if (bytes.length < expectedTLVTotalSize) {
-      throw new ValueError('`bytes` does not long enough');
-    }
-    const value = bytes.slice(typeSize + lengthSize, expectedTLVTotalSize);
-    return new TLV(type, value);
-  }
-
-  serialize(): Uint8Array {
-    const typeBytes = this.type.serialize();
-    const lengthBytes = new Short(this.value.length).serialize();
-    const valueBytes = this.value;
-    return concatUint8Array(
-      concatUint8Array(typeBytes, lengthBytes),
-      valueBytes
-    );
-  }
-}
+import { concatUint8Array } from './utils';
+import { NotImplemented, ValueError } from './exceptions';
 
 function deserializeSMPTLV(tlv: TLV): MPI[] {
   let bytes = tlv.value;
@@ -240,13 +71,10 @@ abstract class BaseSMPMessage {
   abstract toTLV(): TLV;
 }
 
-// const TLVTypePadding = new Short(0);
 const TLVTypeSMPMessage1 = new Short(2);
 const TLVTypeSMPMessage2 = new Short(3);
 const TLVTypeSMPMessage3 = new Short(4);
 const TLVTypeSMPMessage4 = new Short(5);
-// const TLVTypeSMPMessageAbort = new Short(6);
-// const TLVTypeSMPMessage1Q = new Short(7);
 
 class SMPMessage1 extends BaseSMPMessage {
   wireValues: [MultiplicativeGroup, BN, BN, MultiplicativeGroup, BN, BN];
@@ -412,17 +240,4 @@ class SMPMessage4 extends BaseSMPMessage {
   }
 }
 
-export {
-  BaseFixedInt,
-  BaseSMPMessage,
-  SMPMessage1,
-  SMPMessage2,
-  SMPMessage3,
-  SMPMessage4,
-  Byte,
-  Short,
-  Int,
-  MPI,
-  TLV,
-  concatUint8Array,
-};
+export { BaseSMPMessage, SMPMessage1, SMPMessage2, SMPMessage3, SMPMessage4 };

--- a/src/msgs.ts
+++ b/src/msgs.ts
@@ -411,4 +411,5 @@ export {
   Int,
   MPI,
   TLV,
+  concatUint8Array,
 };

--- a/src/msgs.ts
+++ b/src/msgs.ts
@@ -212,6 +212,8 @@ function serializeSMPTLV(
 }
 
 abstract class BaseSMPMessage {
+  abstract wireValues: (BN | MultiplicativeGroup)[];
+
   static getMPIsfromTLV(
     type: BaseFixedInt,
     expectedLength: number,

--- a/src/msgs.ts
+++ b/src/msgs.ts
@@ -19,12 +19,12 @@ abstract class BaseSerializable {
   abstract serialize(): Uint8Array;
 }
 
-class BaseFixedIntClass extends BaseSerializable {
+class BaseFixedInt extends BaseSerializable {
   static size: number;
   constructor(readonly value: number) {
     super();
   }
-  static deserialize(_: Uint8Array): BaseFixedIntClass {
+  static deserialize(_: Uint8Array): BaseFixedInt {
     throw new NotImplemented(); // Make tsc happy
   }
   serialize(): Uint8Array {
@@ -51,15 +51,12 @@ function concatUint8Array(a: Uint8Array, b: Uint8Array): Uint8Array {
   return c;
 }
 
-function createFixedIntClass(size: number): typeof BaseFixedIntClass {
-  class FixedIntClass extends BaseFixedIntClass {
+function createFixedIntClass(size: number): typeof BaseFixedInt {
+  class FixedIntClass extends BaseFixedInt {
     static size: number = size;
 
     static deserialize(bytes: Uint8Array): FixedIntClass {
       if (bytes.length !== size) {
-        console.log(
-          `!@# createFixedIntClass: bytes.length=${bytes.length}, size=${size}`
-        );
         throw new ValueError();
       }
       return new FixedIntClass(uint8ArrayToNumber(bytes));
@@ -112,7 +109,7 @@ class MPI implements BaseSerializable {
 }
 
 class TLV extends BaseSerializable {
-  constructor(readonly type: BaseFixedIntClass, readonly value: Uint8Array) {
+  constructor(readonly type: BaseFixedInt, readonly value: Uint8Array) {
     super();
   }
 
@@ -184,7 +181,7 @@ function deserializeSMPTLV(tlv: TLV): MPI[] {
 }
 
 function serializeSMPTLV(
-  type: BaseFixedIntClass,
+  type: BaseFixedInt,
   ...elements: (BN | MultiplicativeGroup)[]
 ): TLV {
   const length = new Int(elements.length);
@@ -203,7 +200,7 @@ function serializeSMPTLV(
 
 abstract class BaseSMPMessage {
   static getMPIsfromTLV(
-    type: BaseFixedIntClass,
+    type: BaseFixedInt,
     expectedLength: number,
     tlv: TLV
   ): MPI[] {
@@ -401,6 +398,7 @@ class SMPMessage4 extends BaseSMPMessage {
 }
 
 export {
+  BaseFixedInt,
   BaseSMPMessage,
   SMPMessage1,
   SMPMessage2,

--- a/src/multiplicativeGroup.ts
+++ b/src/multiplicativeGroup.ts
@@ -1,5 +1,8 @@
 import BN from 'bn.js';
 
+/**
+ * A general interface of a [group element](https://en.wikipedia.org/wiki/Group_(mathematics)).
+ */
 interface IGroup {
   identity(): IGroup;
   operate(g: IGroup): IGroup;
@@ -8,6 +11,9 @@ interface IGroup {
   equal(g: IGroup): boolean;
 }
 
+/**
+ * A base class for a group element with `exponentiate` implemented.
+ */
 abstract class BaseGroup implements IGroup {
   abstract identity(): BaseGroup;
   abstract operate(g: BaseGroup): BaseGroup;
@@ -37,6 +43,9 @@ abstract class BaseGroup implements IGroup {
   }
 }
 
+/**
+ * An implementation of the [Multiplicative group of integer modulo n](https://en.wikipedia.org/wiki/Multiplicative_group_of_integers_modulo_n).
+ */
 class MultiplicativeGroup extends BaseGroup {
   constructor(readonly n: BN, readonly value: BN) {
     super();

--- a/src/proofs.ts
+++ b/src/proofs.ts
@@ -1,11 +1,33 @@
+/**
+ * Introduction to the proof algorithms can be found in
+ *  - section APPENDIX  in https://cypherpunks.ca/~iang/pubs/impauth.pdf
+ *  - section 2 in https://www.win.tue.nl/~berry/papers/dam.pdf
+ * Implementation details can be found in the OTR spec version 3
+ *  - https://otr.cypherpunks.ca/Protocol-v3-4.1.1.html
+ * @packageDocumentation
+ */
+
 import BN from 'bn.js';
 
 import { MultiplicativeGroup } from './multiplicativeGroup';
 
 type THashFunc = (...args: BN[]) => BN;
 
+/**
+ * Proof of discrete log based on Schnorr’s protocol, which proves that we know `x`
+ * s.t. `y = g**x` without leaking x.
+ */
 type ProofDiscreteLog = { c: BN; d: BN };
+/**
+ * Proof of equality of discrete coordinates based on Boudot, Schoenmakers and Traoré’s extension
+ * to a protocol by Chaum and Pedersen. The proof proves that given `g0`, `g1`, `g2`, `y0` and `y1`,
+ * we know `x0` and `x1` s.t. `y0 = g0**x0` and `y1 = (g1**x0)*(g2**x1)`.
+ */
 type ProofEqualDiscreteCoordinates = { c: BN; d0: BN; d1: BN };
+/**
+ * Proof of equality of two discrete logs, i.e. given `g0`, `g1`, `y0` and `y1`, we know `x0` s.t.
+ * `y0 = g0**x0` and `y1 = g1**x1`. It's based on the protocol by Chaum and Pedersen.
+ */
 type ProofEqualDiscreteLogs = { c: BN; d: BN };
 
 function makeProofDiscreteLog(

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,7 +4,7 @@ import BN from 'bn.js';
 
 import { Config, defaultConfig } from './config';
 import { SMPStateMachine, TypeTLVOrNull } from './smp';
-import { TLV } from './dataTypes';
+import { TLV } from './msgs';
 import { FailedToReadData, SMPStateError } from './exceptions';
 
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,7 +4,7 @@ import BN from 'bn.js';
 
 import { Config, defaultConfig } from './config';
 import { SMPStateMachine, TypeTLVOrNull } from './smp';
-import { TLV } from './msgs';
+import { TLV } from './dataTypes';
 import { FailedToReadData, SMPStateError } from './exceptions';
 
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));

--- a/src/smp.ts
+++ b/src/smp.ts
@@ -27,13 +27,9 @@ import {
   SMPNotFinished,
 } from './exceptions';
 
-import {
-  SMPMessage1,
-  SMPMessage2,
-  SMPMessage3,
-  SMPMessage4,
-  TLV,
-} from './msgs';
+import { SMPMessage1, SMPMessage2, SMPMessage3, SMPMessage4 } from './msgs';
+
+import { TLV } from './dataTypes';
 
 type TypeTLVOrNull = TLV | null;
 

--- a/src/smp.ts
+++ b/src/smp.ts
@@ -29,7 +29,7 @@ import {
 
 import { SMPMessage1, SMPMessage2, SMPMessage3, SMPMessage4 } from './msgs';
 
-import { TLV } from './dataTypes';
+import { TLV } from './msgs';
 
 type TypeTLVOrNull = TLV | null;
 

--- a/src/smp.ts
+++ b/src/smp.ts
@@ -4,7 +4,7 @@ import BN from 'bn.js';
 
 import { MultiplicativeGroup } from './multiplicativeGroup';
 import { Config, defaultConfig } from './config';
-import { sha256ToInt } from './hash';
+import { smpHash } from './hash';
 
 import {
   makeProofDiscreteLog,
@@ -56,9 +56,9 @@ abstract class BaseSMPState implements ISMPState {
   abstract transit(msg: TypeTLVOrNull): [ISMPState, TypeTLVOrNull];
   abstract getResult(): boolean | null;
 
-  getHashFunc(this: BaseSMPState, version: BN): THashFunc {
+  getHashFunc(version: number): THashFunc {
     return (...args: BN[]): BN => {
-      return sha256ToInt(this.config.modulusSize, version, ...args);
+      return smpHash(version, ...args);
     };
   }
 
@@ -68,7 +68,7 @@ abstract class BaseSMPState implements ISMPState {
   }
 
   makeDHPubkey(
-    version: BN,
+    version: number,
     secretKey: BN
   ): [MultiplicativeGroup, ProofDiscreteLog] {
     const pubkey = this.g1.exponentiate(secretKey);
@@ -83,7 +83,7 @@ abstract class BaseSMPState implements ISMPState {
   }
 
   verifyDHPubkey(
-    version: BN,
+    version: number,
     pubkey: MultiplicativeGroup,
     proof: ProofDiscreteLog
   ): boolean {
@@ -108,7 +108,7 @@ abstract class BaseSMPState implements ISMPState {
   }
 
   makePLQL(
-    version: BN,
+    version: number,
     g2: MultiplicativeGroup,
     g3: MultiplicativeGroup
   ): [MultiplicativeGroup, MultiplicativeGroup, ProofEqualDiscreteCoordinates] {
@@ -132,7 +132,7 @@ abstract class BaseSMPState implements ISMPState {
   }
 
   verifyPRQRProof(
-    version: BN,
+    version: number,
     g2: MultiplicativeGroup,
     g3: MultiplicativeGroup,
     pR: MultiplicativeGroup,
@@ -151,7 +151,7 @@ abstract class BaseSMPState implements ISMPState {
   }
 
   makeRL(
-    version: BN,
+    version: number,
     s3: BN,
     qa: MultiplicativeGroup,
     qb: MultiplicativeGroup
@@ -170,7 +170,7 @@ abstract class BaseSMPState implements ISMPState {
   }
 
   verifyRR(
-    version: BN,
+    version: number,
     g3R: MultiplicativeGroup,
     rR: MultiplicativeGroup,
     proof: ProofEqualDiscreteLogs,
@@ -207,8 +207,8 @@ class SMPState1 extends BaseSMPState {
   transit(tlv: TypeTLVOrNull): [ISMPState, TypeTLVOrNull] {
     if (tlv === null) {
       /* Step 0: Alice initaites smp, sending `g2a`, `g3a` to Bob. */
-      const [g2a, g2aProof] = this.makeDHPubkey(new BN(1), this.s2);
-      const [g3a, g3aProof] = this.makeDHPubkey(new BN(2), this.s3);
+      const [g2a, g2aProof] = this.makeDHPubkey(1, this.s2);
+      const [g3a, g3aProof] = this.makeDHPubkey(2, this.s3);
       const msg = new SMPMessage1(g2a, g2aProof, g3a, g3aProof);
       const state = new SMPState2(
         this.x,
@@ -233,18 +233,18 @@ class SMPState1 extends BaseSMPState {
         throw new InvalidElement();
       }
       // Verify the proofs
-      if (!this.verifyDHPubkey(new BN(1), msg.g2a, msg.g2aProof)) {
+      if (!this.verifyDHPubkey(1, msg.g2a, msg.g2aProof)) {
         throw new InvalidProof();
       }
-      if (!this.verifyDHPubkey(new BN(2), msg.g3a, msg.g3aProof)) {
+      if (!this.verifyDHPubkey(2, msg.g3a, msg.g3aProof)) {
         throw new InvalidProof();
       }
-      const [g2b, g2bProof] = this.makeDHPubkey(new BN(3), this.s2);
-      const [g3b, g3bProof] = this.makeDHPubkey(new BN(4), this.s3);
+      const [g2b, g2bProof] = this.makeDHPubkey(3, this.s2);
+      const [g3b, g3bProof] = this.makeDHPubkey(4, this.s3);
       const g2 = this.makeDHSharedSecret(msg.g2a, this.s2);
       const g3 = this.makeDHSharedSecret(msg.g3a, this.s3);
       // Make `Pb` and `Qb`
-      const [pb, qb, pbqbProof] = this.makePLQL(new BN(5), g2, g3);
+      const [pb, qb, pbqbProof] = this.makePLQL(5, g2, g3);
 
       const msg2 = new SMPMessage2(
         g2b,
@@ -306,24 +306,22 @@ class SMPState2 extends BaseSMPState {
     ) {
       throw new InvalidElement();
     }
-    if (!this.verifyDHPubkey(new BN(3), msg.g2b, msg.g2bProof)) {
+    if (!this.verifyDHPubkey(3, msg.g2b, msg.g2bProof)) {
       throw new InvalidProof();
     }
-    if (!this.verifyDHPubkey(new BN(4), msg.g3b, msg.g3bProof)) {
+    if (!this.verifyDHPubkey(4, msg.g3b, msg.g3bProof)) {
       throw new InvalidProof();
     }
     // Perform DH
     const g2 = this.makeDHSharedSecret(msg.g2b, this.s2);
     const g3 = this.makeDHSharedSecret(msg.g3b, this.s3);
-    if (
-      !this.verifyPRQRProof(new BN(5), g2, g3, msg.pb, msg.qb, msg.pbqbProof)
-    ) {
+    if (!this.verifyPRQRProof(5, g2, g3, msg.pb, msg.qb, msg.pbqbProof)) {
       throw new InvalidProof();
     }
     // Calculate `Pa` and `Qa`
-    const [pa, qa, paqaProof] = this.makePLQL(new BN(6), g2, g3);
+    const [pa, qa, paqaProof] = this.makePLQL(6, g2, g3);
     // Calculate `Ra`
-    const [ra, raProof] = this.makeRL(new BN(7), this.s3, qa, msg.qb);
+    const [ra, raProof] = this.makeRL(7, this.s3, qa, msg.qb);
 
     const msg3 = new SMPMessage3(pa, qa, paqaProof, ra, raProof);
     // Advance the step
@@ -387,24 +385,15 @@ class SMPState3 extends BaseSMPState {
       throw new InvalidElement();
     }
     if (
-      !this.verifyPRQRProof(
-        new BN(6),
-        this.g2,
-        this.g3,
-        msg.pa,
-        msg.qa,
-        msg.paqaProof
-      )
+      !this.verifyPRQRProof(6, this.g2, this.g3, msg.pa, msg.qa, msg.paqaProof)
     ) {
       throw new InvalidProof();
     }
     // `Ra`
-    if (
-      !this.verifyRR(new BN(7), this.g3R, msg.ra, msg.raProof, msg.qa, this.qL)
-    ) {
+    if (!this.verifyRR(7, this.g3R, msg.ra, msg.raProof, msg.qa, this.qL)) {
       throw new InvalidProof();
     }
-    const [rb, rbProof] = this.makeRL(new BN(8), this.s3, msg.qa, this.qL);
+    const [rb, rbProof] = this.makeRL(8, this.s3, msg.qa, this.qL);
     const msg4 = new SMPMessage4(rb, rbProof);
     const rab = this.makeRab(this.s3, msg.ra);
     const state = new SMPStateFinished(
@@ -454,9 +443,7 @@ class SMPState4 extends BaseSMPState {
     if (!this.verifyMultiplicativeGroup(msg.rb)) {
       throw new InvalidElement();
     }
-    if (
-      !this.verifyRR(new BN(8), this.g3R, msg.rb, msg.rbProof, this.qL, this.qR)
-    ) {
+    if (!this.verifyRR(8, this.g3R, msg.rb, msg.rbProof, this.qL, this.qR)) {
       throw new InvalidProof();
     }
     const rab = this.makeRab(this.s3, msg.rb);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,8 @@
+function concatUint8Array(a: Uint8Array, b: Uint8Array): Uint8Array {
+  let c = new Uint8Array(a.length + b.length);
+  c.set(a);
+  c.set(b, a.length);
+  return c;
+}
+
+export { concatUint8Array };

--- a/test/dataTypes.test.ts
+++ b/test/dataTypes.test.ts
@@ -1,9 +1,8 @@
-import * as TCP from 'net';
 import BN from 'bn.js';
 
 import { concatUint8Array } from '../src/utils';
-import { Byte, Short, Int, MPI, TLV } from '../src/dataTypes';
-import { ValueError, FailedToReadData } from '../src/exceptions';
+import { Byte, Short, Int, MPI } from '../src/dataTypes';
+import { ValueError } from '../src/exceptions';
 
 describe('Fixed types', () => {
   const types = [Byte, Short, Int];
@@ -100,80 +99,6 @@ describe('MPI(variable-length integer)', () => {
     // Length too long
     expect(() => {
       MPI.deserialize(new Uint8Array([0, 0, 0, 2, 0]));
-    }).toThrowError(ValueError);
-  });
-});
-
-describe('TLV', () => {
-  test('succeeds', () => {
-    const types = [new Short(3), new Short(5), new Short(7)];
-    const values = [
-      new Uint8Array([5566, 5577]),
-      new Uint8Array([1, 2, 3, 4, 5]),
-      new Uint8Array([]),
-    ];
-    const expectedSerialized = [
-      new Uint8Array([0, 3, 0, 2, 5566, 5577]),
-      new Uint8Array([0, 5, 0, 5, 1, 2, 3, 4, 5]),
-      new Uint8Array([0, 7, 0, 0]),
-    ];
-    for (const index in values) {
-      const type = types[index];
-      const value = values[index];
-      const tlv = new TLV(type, value);
-      const expected = expectedSerialized[index];
-      expect(tlv.serialize()).toEqual(expected);
-      const tlvFromExpected = TLV.deserialize(expected);
-      expect(tlvFromExpected.type.value).toEqual(tlv.type.value);
-      expect(tlvFromExpected.value).toEqual(tlv.value);
-    }
-  });
-
-  test('readFromSocket', async () => {
-    const sendTLV = async (bytes: Uint8Array): Promise<TLV> => {
-      const ip = '127.0.0.1';
-      const port = 4000;
-
-      const server = TCP.createServer((sock: TCP.Socket) => {
-        sock.write(bytes);
-      });
-      server.listen(port, ip);
-      const sockClient = new TCP.Socket();
-      return new Promise((resolve, reject) => {
-        sockClient.connect(port, ip, () => {});
-        sockClient.on('readable', () => {
-          let tlv: TLV;
-          try {
-            tlv = TLV.readFromSocket(sockClient);
-            resolve(tlv);
-          } catch (e) {
-            reject(e);
-          } finally {
-            server.close();
-            sockClient.destroy();
-          }
-        });
-      });
-    };
-    // Correct format
-    const correctBytes = new Uint8Array([0, 0, 0, 2, 2, 3]);
-    const tlv = await sendTLV(correctBytes);
-    expect(tlv.type.value).toEqual(0);
-    expect(tlv.value).toEqual(new Uint8Array([2, 3]));
-    // Wrong format
-    const corruptedBytes = new Uint8Array([0, 0, 0, 2, 2]);
-    await expect(sendTLV(corruptedBytes)).rejects.toThrowError(
-      FailedToReadData
-    );
-  });
-  test('deserialize fails', () => {
-    // Empty
-    expect(() => {
-      TLV.deserialize(new Uint8Array([]));
-    }).toThrowError(ValueError);
-    // Wrong length
-    expect(() => {
-      TLV.deserialize(new Uint8Array([0, 0, 0, 3, 1, 1]));
     }).toThrowError(ValueError);
   });
 });

--- a/test/dataTypes.test.ts
+++ b/test/dataTypes.test.ts
@@ -1,0 +1,179 @@
+import * as TCP from 'net';
+import BN from 'bn.js';
+
+import { concatUint8Array } from '../src/utils';
+import { Byte, Short, Int, MPI, TLV } from '../src/dataTypes';
+import { ValueError, FailedToReadData } from '../src/exceptions';
+
+describe('Fixed types', () => {
+  const types = [Byte, Short, Int];
+  test('succeeds', () => {
+    const expectedSize = [1, 2, 4];
+    const expectedValue = [255, 255, 255];
+    const expectedSerialized = [
+      new Uint8Array([255]),
+      new Uint8Array([0, 255]),
+      new Uint8Array([0, 0, 0, 255]),
+    ];
+    for (const index in types) {
+      const Type = types[index];
+      const b = new Type(expectedValue[index]);
+      expect(Type.size).toEqual(expectedSize[index]);
+      expect(b.value).toEqual(expectedValue[index]);
+      expect(b.serialize()).toEqual(expectedSerialized[index]);
+      expect(b.value).toEqual(
+        Type.deserialize(expectedSerialized[index]).value
+      );
+    }
+  });
+  test('constructor fails', () => {
+    // Too large
+    for (const index in types) {
+      const Type = types[index];
+      expect(() => {
+        new Type(2 ** (Type.size * 8));
+      }).toThrowError(ValueError);
+    }
+    // Negative
+    for (const Type of types) {
+      expect(() => {
+        new Type(-1);
+      }).toThrowError(ValueError);
+    }
+  });
+});
+
+describe('MPI(variable-length integer)', () => {
+  test('succeeds', () => {
+    const values = [
+      new BN(0),
+      new BN(256),
+      new BN(2).pow(new BN(64)).subn(1), // 2**64 - 1
+    ];
+    const expectedSerialized = [
+      new Uint8Array([0, 0, 0, 1, 0]),
+      new Uint8Array([0, 0, 0, 2, 1, 0]),
+      new Uint8Array([0, 0, 0, 8, 255, 255, 255, 255, 255, 255, 255, 255]),
+    ];
+    for (const index in values) {
+      const mpi = new MPI(values[index]);
+      const expected = expectedSerialized[index];
+      expect(mpi.serialize()).toEqual(expected);
+      expect(MPI.deserialize(expected).value.eq(mpi.value));
+    }
+  });
+  test('consume', () => {
+    const bytes = concatUint8Array(
+      new Uint8Array([0, 0, 0, 1, 0]),
+      new Uint8Array([0, 0, 0, 2, 1, 0])
+    );
+    const [mpi1, bytesRemaining] = MPI.consume(bytes);
+    expect(mpi1.value.eqn(0)).toBeTruthy();
+    const [mpi2, bytesRemaining2] = MPI.consume(bytesRemaining);
+    expect(mpi2.value.eqn(256)).toBeTruthy();
+    expect(() => {
+      MPI.consume(bytesRemaining2);
+    }).toThrowError(ValueError);
+    // We can consume only the prefix, i.e. [0, 0, 0, 1, 1].
+    const b = new Uint8Array([0, 0, 0, 1, 1, 1]);
+    const [mpi3, bRemaining] = MPI.consume(b);
+    expect(() => {
+      expect(mpi3.value.eqn(1)).toBeTruthy();
+      expect(bRemaining).toEqual(new Uint8Array([1]));
+    });
+  });
+  test('constructor fails', () => {
+    // Negative
+    expect(() => {
+      new MPI(new BN(-1));
+    }).toThrowError(ValueError);
+  });
+  test('deserialize fails', () => {
+    // Empty
+    expect(() => {
+      MPI.deserialize(new Uint8Array([]));
+    }).toThrowError(ValueError);
+    // Length too short
+    expect(() => {
+      MPI.deserialize(new Uint8Array([0, 0, 0, 1, 1, 1]));
+    }).toThrowError(ValueError);
+    // Length too long
+    expect(() => {
+      MPI.deserialize(new Uint8Array([0, 0, 0, 2, 0]));
+    }).toThrowError(ValueError);
+  });
+});
+
+describe('TLV', () => {
+  test('succeeds', () => {
+    const types = [new Short(3), new Short(5), new Short(7)];
+    const values = [
+      new Uint8Array([5566, 5577]),
+      new Uint8Array([1, 2, 3, 4, 5]),
+      new Uint8Array([]),
+    ];
+    const expectedSerialized = [
+      new Uint8Array([0, 3, 0, 2, 5566, 5577]),
+      new Uint8Array([0, 5, 0, 5, 1, 2, 3, 4, 5]),
+      new Uint8Array([0, 7, 0, 0]),
+    ];
+    for (const index in values) {
+      const type = types[index];
+      const value = values[index];
+      const tlv = new TLV(type, value);
+      const expected = expectedSerialized[index];
+      expect(tlv.serialize()).toEqual(expected);
+      const tlvFromExpected = TLV.deserialize(expected);
+      expect(tlvFromExpected.type.value).toEqual(tlv.type.value);
+      expect(tlvFromExpected.value).toEqual(tlv.value);
+    }
+  });
+
+  test('readFromSocket', async () => {
+    const sendTLV = async (bytes: Uint8Array): Promise<TLV> => {
+      const ip = '127.0.0.1';
+      const port = 4000;
+
+      const server = TCP.createServer((sock: TCP.Socket) => {
+        sock.write(bytes);
+      });
+      server.listen(port, ip);
+      const sockClient = new TCP.Socket();
+      return new Promise((resolve, reject) => {
+        sockClient.connect(port, ip, () => {});
+        sockClient.on('readable', () => {
+          let tlv: TLV;
+          try {
+            tlv = TLV.readFromSocket(sockClient);
+            resolve(tlv);
+          } catch (e) {
+            reject(e);
+          } finally {
+            server.close();
+            sockClient.destroy();
+          }
+        });
+      });
+    };
+    // Correct format
+    const correctBytes = new Uint8Array([0, 0, 0, 2, 2, 3]);
+    const tlv = await sendTLV(correctBytes);
+    expect(tlv.type.value).toEqual(0);
+    expect(tlv.value).toEqual(new Uint8Array([2, 3]));
+    // Wrong format
+    const corruptedBytes = new Uint8Array([0, 0, 0, 2, 2]);
+    await expect(sendTLV(corruptedBytes)).rejects.toThrowError(
+      FailedToReadData
+    );
+  });
+  test('deserialize fails', () => {
+    // Empty
+    expect(() => {
+      TLV.deserialize(new Uint8Array([]));
+    }).toThrowError(ValueError);
+    // Wrong length
+    expect(() => {
+      TLV.deserialize(new Uint8Array([0, 0, 0, 3, 1, 1]));
+    }).toThrowError(ValueError);
+  });
+});

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -1,16 +1,51 @@
 import BN from 'bn.js';
 
-import { sha256ToInt } from '../src/hash';
-import { defaultConfig } from '../src/config';
+import { smpHash } from '../src/hash';
 
-describe('sha256ToInt', () => {
-  const intSize = defaultConfig.modulusSize;
+describe('smpHash', () => {
+  const version1 = 1;
+  const version2 = 2;
+  const args1 = [new BN(1), new BN(2)];
+  const args2 = [new BN(2), new BN(2)];
+
   test('hardcoded test', () => {
-    expect(sha256ToInt(intSize, new BN(1))).toEqual(
+    // empty args
+    expect(smpHash(version1)).toEqual(
       new BN(
-        '57153b76f61c2badabeb23203d690a2fe5509e76d1196658af70b2daf62c1aec',
+        '4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a',
         'hex'
       )
     );
+    // with args
+    expect(smpHash(version1, ...args1)).toEqual(
+      new BN(
+        'c978fefeb22ed51f470af5e695f4159d3bd19f6da8e272762e3e4252efcb6431',
+        'hex'
+      )
+    );
+  });
+
+  test('same versions and args', () => {
+    const res1 = smpHash(version1, ...args1);
+    const res2 = smpHash(version1, ...args1);
+    expect(res1.eq(res2)).toBeTruthy();
+  });
+
+  test('same versions but different args', () => {
+    const res1 = smpHash(version1, ...args1);
+    const res2 = smpHash(version1, ...args2);
+    expect(res1.eq(res2)).toBeFalsy();
+  });
+
+  test('different versions and same args', () => {
+    const res1 = smpHash(version1, ...args1);
+    const res2 = smpHash(version2, ...args1);
+    expect(res1.eq(res2)).toBeFalsy();
+  });
+
+  test('different versions and different args', () => {
+    const res1 = smpHash(version1, ...args1);
+    const res2 = smpHash(version2, ...args2);
+    expect(res1.eq(res2)).toBeFalsy();
   });
 });

--- a/test/msgs.test.ts
+++ b/test/msgs.test.ts
@@ -1,14 +1,14 @@
+import * as TCP from 'net';
 import BN from 'bn.js';
 
 import { Byte, Short, Int, MPI, TLV, concatUint8Array } from '../src/msgs';
-import { ValueError } from '../src/exceptions';
+import { ValueError, FailedToReadData } from '../src/exceptions';
 
-// TODO: Add failure cases
 // TODO: Add tests for `SMPMessage`s
 
 describe('Fixed types', () => {
   const types = [Byte, Short, Int];
-  test('hardcoded test', () => {
+  test('succeeds', () => {
     const expectedSize = [1, 2, 4];
     const expectedValue = [255, 255, 255];
     const expectedSerialized = [
@@ -45,7 +45,7 @@ describe('Fixed types', () => {
 });
 
 describe('MPI(variable-length integer)', () => {
-  test('hardcoded test', () => {
+  test('succeeds', () => {
     const values = [
       new BN(0),
       new BN(256),
@@ -102,18 +102,18 @@ describe('MPI(variable-length integer)', () => {
 });
 
 describe('TLV', () => {
-  const types = [new Short(3), new Short(5), new Short(7)];
-  const values = [
-    new Uint8Array([5566, 5577]),
-    new Uint8Array([1, 2, 3, 4, 5]),
-    new Uint8Array([]),
-  ];
-  const expectedSerialized = [
-    new Uint8Array([0, 3, 0, 2, 5566, 5577]),
-    new Uint8Array([0, 5, 0, 5, 1, 2, 3, 4, 5]),
-    new Uint8Array([0, 7, 0, 0]),
-  ];
-  test('hardcoded test', () => {
+  test('succeeds', () => {
+    const types = [new Short(3), new Short(5), new Short(7)];
+    const values = [
+      new Uint8Array([5566, 5577]),
+      new Uint8Array([1, 2, 3, 4, 5]),
+      new Uint8Array([]),
+    ];
+    const expectedSerialized = [
+      new Uint8Array([0, 3, 0, 2, 5566, 5577]),
+      new Uint8Array([0, 5, 0, 5, 1, 2, 3, 4, 5]),
+      new Uint8Array([0, 7, 0, 0]),
+    ];
     for (const index in values) {
       const type = types[index];
       const value = values[index];
@@ -124,5 +124,50 @@ describe('TLV', () => {
       expect(tlvFromExpected.type.value).toEqual(tlv.type.value);
       expect(tlvFromExpected.value).toEqual(tlv.value);
     }
+  });
+
+  test('readFromSocket', async () => {
+    const sendTLV = async (bytes: Uint8Array): Promise<void> => {
+      const ip = '127.0.0.1';
+      const port = 4000;
+
+      const server = TCP.createServer((sock: TCP.Socket) => {
+        sock.write(bytes);
+      });
+      server.listen(port, ip);
+      const sockClient = new TCP.Socket();
+      return new Promise((resolve, reject) => {
+        sockClient.connect(port, ip, () => {});
+        sockClient.on('readable', () => {
+          try {
+            TLV.readFromSocket(sockClient);
+          } catch (e) {
+            reject(e);
+          } finally {
+            server.close();
+            sockClient.destroy();
+          }
+          resolve();
+        });
+      });
+    };
+    // Correct format
+    const correctBytes = new Uint8Array([0, 0, 0, 2, 2, 3]);
+    await sendTLV(correctBytes);
+    // Wrong format
+    const corruptedBytes = new Uint8Array([0, 0, 0, 2, 2]);
+    await expect(sendTLV(corruptedBytes)).rejects.toThrowError(
+      FailedToReadData
+    );
+  });
+  test('deserialize fails', () => {
+    // Empty
+    expect(() => {
+      TLV.deserialize(new Uint8Array([]));
+    }).toThrowError(ValueError);
+    // Wrong length
+    expect(() => {
+      TLV.deserialize(new Uint8Array([0, 0, 0, 3, 1, 1]));
+    }).toThrowError(ValueError);
   });
 });

--- a/test/msgs.test.ts
+++ b/test/msgs.test.ts
@@ -1,14 +1,8 @@
-import * as TCP from 'net';
 import BN from 'bn.js';
 
 import { smpHash } from '../src/hash';
+import { Short, TLV } from '../src/dataTypes';
 import {
-  Byte,
-  Short,
-  Int,
-  MPI,
-  TLV,
-  concatUint8Array,
   BaseSMPMessage,
   SMPMessage1,
   SMPMessage2,
@@ -16,186 +10,13 @@ import {
   SMPMessage4,
 } from '../src/msgs';
 import { multiplicativeGroupFactory, secretFactory } from '../src/factories';
-import { ValueError, FailedToReadData } from '../src/exceptions';
+import { ValueError } from '../src/exceptions';
 import { MultiplicativeGroup } from '../src/multiplicativeGroup';
 import {
   makeProofDiscreteLog,
   makeProofEqualDiscreteCoordinates,
   makeProofEqualDiscreteLogs,
 } from '../src/proofs';
-
-describe('Fixed types', () => {
-  const types = [Byte, Short, Int];
-  test('succeeds', () => {
-    const expectedSize = [1, 2, 4];
-    const expectedValue = [255, 255, 255];
-    const expectedSerialized = [
-      new Uint8Array([255]),
-      new Uint8Array([0, 255]),
-      new Uint8Array([0, 0, 0, 255]),
-    ];
-    for (const index in types) {
-      const Type = types[index];
-      const b = new Type(expectedValue[index]);
-      expect(Type.size).toEqual(expectedSize[index]);
-      expect(b.value).toEqual(expectedValue[index]);
-      expect(b.serialize()).toEqual(expectedSerialized[index]);
-      expect(b.value).toEqual(
-        Type.deserialize(expectedSerialized[index]).value
-      );
-    }
-  });
-  test('constructor fails', () => {
-    // Too large
-    for (const index in types) {
-      const Type = types[index];
-      expect(() => {
-        new Type(2 ** (Type.size * 8));
-      }).toThrowError(ValueError);
-    }
-    // Negative
-    for (const Type of types) {
-      expect(() => {
-        new Type(-1);
-      }).toThrowError(ValueError);
-    }
-  });
-});
-
-describe('MPI(variable-length integer)', () => {
-  test('succeeds', () => {
-    const values = [
-      new BN(0),
-      new BN(256),
-      new BN(2).pow(new BN(64)).subn(1), // 2**64 - 1
-    ];
-    const expectedSerialized = [
-      new Uint8Array([0, 0, 0, 1, 0]),
-      new Uint8Array([0, 0, 0, 2, 1, 0]),
-      new Uint8Array([0, 0, 0, 8, 255, 255, 255, 255, 255, 255, 255, 255]),
-    ];
-    for (const index in values) {
-      const mpi = new MPI(values[index]);
-      const expected = expectedSerialized[index];
-      expect(mpi.serialize()).toEqual(expected);
-      expect(MPI.deserialize(expected).value.eq(mpi.value));
-    }
-  });
-  test('consume', () => {
-    const bytes = concatUint8Array(
-      new Uint8Array([0, 0, 0, 1, 0]),
-      new Uint8Array([0, 0, 0, 2, 1, 0])
-    );
-    const [mpi1, bytesRemaining] = MPI.consume(bytes);
-    expect(mpi1.value.eqn(0)).toBeTruthy();
-    const [mpi2, bytesRemaining2] = MPI.consume(bytesRemaining);
-    expect(mpi2.value.eqn(256)).toBeTruthy();
-    expect(() => {
-      MPI.consume(bytesRemaining2);
-    }).toThrowError(ValueError);
-    // We can consume only the prefix, i.e. [0, 0, 0, 1, 1].
-    const b = new Uint8Array([0, 0, 0, 1, 1, 1]);
-    const [mpi3, bRemaining] = MPI.consume(b);
-    expect(() => {
-      expect(mpi3.value.eqn(1)).toBeTruthy();
-      expect(bRemaining).toEqual(new Uint8Array([1]));
-    });
-  });
-  test('constructor fails', () => {
-    // Negative
-    expect(() => {
-      new MPI(new BN(-1));
-    }).toThrowError(ValueError);
-  });
-  test('deserialize fails', () => {
-    // Empty
-    expect(() => {
-      MPI.deserialize(new Uint8Array([]));
-    }).toThrowError(ValueError);
-    // Length too short
-    expect(() => {
-      MPI.deserialize(new Uint8Array([0, 0, 0, 1, 1, 1]));
-    }).toThrowError(ValueError);
-    // Length too long
-    expect(() => {
-      MPI.deserialize(new Uint8Array([0, 0, 0, 2, 0]));
-    }).toThrowError(ValueError);
-  });
-});
-
-describe('TLV', () => {
-  test('succeeds', () => {
-    const types = [new Short(3), new Short(5), new Short(7)];
-    const values = [
-      new Uint8Array([5566, 5577]),
-      new Uint8Array([1, 2, 3, 4, 5]),
-      new Uint8Array([]),
-    ];
-    const expectedSerialized = [
-      new Uint8Array([0, 3, 0, 2, 5566, 5577]),
-      new Uint8Array([0, 5, 0, 5, 1, 2, 3, 4, 5]),
-      new Uint8Array([0, 7, 0, 0]),
-    ];
-    for (const index in values) {
-      const type = types[index];
-      const value = values[index];
-      const tlv = new TLV(type, value);
-      const expected = expectedSerialized[index];
-      expect(tlv.serialize()).toEqual(expected);
-      const tlvFromExpected = TLV.deserialize(expected);
-      expect(tlvFromExpected.type.value).toEqual(tlv.type.value);
-      expect(tlvFromExpected.value).toEqual(tlv.value);
-    }
-  });
-
-  test('readFromSocket', async () => {
-    const sendTLV = async (bytes: Uint8Array): Promise<TLV> => {
-      const ip = '127.0.0.1';
-      const port = 4000;
-
-      const server = TCP.createServer((sock: TCP.Socket) => {
-        sock.write(bytes);
-      });
-      server.listen(port, ip);
-      const sockClient = new TCP.Socket();
-      return new Promise((resolve, reject) => {
-        sockClient.connect(port, ip, () => {});
-        sockClient.on('readable', () => {
-          let tlv: TLV;
-          try {
-            tlv = TLV.readFromSocket(sockClient);
-            resolve(tlv);
-          } catch (e) {
-            reject(e);
-          } finally {
-            server.close();
-            sockClient.destroy();
-          }
-        });
-      });
-    };
-    // Correct format
-    const correctBytes = new Uint8Array([0, 0, 0, 2, 2, 3]);
-    const tlv = await sendTLV(correctBytes);
-    expect(tlv.type.value).toEqual(0);
-    expect(tlv.value).toEqual(new Uint8Array([2, 3]));
-    // Wrong format
-    const corruptedBytes = new Uint8Array([0, 0, 0, 2, 2]);
-    await expect(sendTLV(corruptedBytes)).rejects.toThrowError(
-      FailedToReadData
-    );
-  });
-  test('deserialize fails', () => {
-    // Empty
-    expect(() => {
-      TLV.deserialize(new Uint8Array([]));
-    }).toThrowError(ValueError);
-    // Wrong length
-    expect(() => {
-      TLV.deserialize(new Uint8Array([0, 0, 0, 3, 1, 1]));
-    }).toThrowError(ValueError);
-  });
-});
 
 describe('BaseSMPMessage', () => {
   test('getMPIsfromTLV succeeds', () => {

--- a/test/msgs.test.ts
+++ b/test/msgs.test.ts
@@ -112,9 +112,13 @@ describe('MPI(variable-length integer)', () => {
     expect(() => {
       MPI.deserialize(new Uint8Array([]));
     }).toThrowError(ValueError);
-    // Wrong length
+    // Length too short
     expect(() => {
       MPI.deserialize(new Uint8Array([0, 0, 0, 1, 1, 1]));
+    }).toThrowError(ValueError);
+    // Length too long
+    expect(() => {
+      MPI.deserialize(new Uint8Array([0, 0, 0, 2, 0]));
     }).toThrowError(ValueError);
   });
 });

--- a/test/msgs.test.ts
+++ b/test/msgs.test.ts
@@ -1,22 +1,99 @@
+import * as TCP from 'net';
+
 import BN from 'bn.js';
 
 import { smpHash } from '../src/hash';
-import { Short, TLV } from '../src/dataTypes';
+import { Short } from '../src/dataTypes';
 import {
   BaseSMPMessage,
   SMPMessage1,
   SMPMessage2,
   SMPMessage3,
   SMPMessage4,
+  TLV,
 } from '../src/msgs';
 import { multiplicativeGroupFactory, secretFactory } from '../src/factories';
-import { ValueError } from '../src/exceptions';
+import { FailedToReadData, ValueError } from '../src/exceptions';
 import { MultiplicativeGroup } from '../src/multiplicativeGroup';
 import {
   makeProofDiscreteLog,
   makeProofEqualDiscreteCoordinates,
   makeProofEqualDiscreteLogs,
 } from '../src/proofs';
+
+describe('TLV', () => {
+  test('succeeds', () => {
+    const types = [new Short(3), new Short(5), new Short(7)];
+    const values = [
+      new Uint8Array([5566, 5577]),
+      new Uint8Array([1, 2, 3, 4, 5]),
+      new Uint8Array([]),
+    ];
+    const expectedSerialized = [
+      new Uint8Array([0, 3, 0, 2, 5566, 5577]),
+      new Uint8Array([0, 5, 0, 5, 1, 2, 3, 4, 5]),
+      new Uint8Array([0, 7, 0, 0]),
+    ];
+    for (const index in values) {
+      const type = types[index];
+      const value = values[index];
+      const tlv = new TLV(type, value);
+      const expected = expectedSerialized[index];
+      expect(tlv.serialize()).toEqual(expected);
+      const tlvFromExpected = TLV.deserialize(expected);
+      expect(tlvFromExpected.type.value).toEqual(tlv.type.value);
+      expect(tlvFromExpected.value).toEqual(tlv.value);
+    }
+  });
+
+  test('readFromSocket', async () => {
+    const sendTLV = async (bytes: Uint8Array): Promise<TLV> => {
+      const ip = '127.0.0.1';
+      const port = 4000;
+
+      const server = TCP.createServer((sock: TCP.Socket) => {
+        sock.write(bytes);
+      });
+      server.listen(port, ip);
+      const sockClient = new TCP.Socket();
+      return new Promise((resolve, reject) => {
+        sockClient.connect(port, ip, () => {});
+        sockClient.on('readable', () => {
+          let tlv: TLV;
+          try {
+            tlv = TLV.readFromSocket(sockClient);
+            resolve(tlv);
+          } catch (e) {
+            reject(e);
+          } finally {
+            server.close();
+            sockClient.destroy();
+          }
+        });
+      });
+    };
+    // Correct format
+    const correctBytes = new Uint8Array([0, 0, 0, 2, 2, 3]);
+    const tlv = await sendTLV(correctBytes);
+    expect(tlv.type.value).toEqual(0);
+    expect(tlv.value).toEqual(new Uint8Array([2, 3]));
+    // Wrong format
+    const corruptedBytes = new Uint8Array([0, 0, 0, 2, 2]);
+    await expect(sendTLV(corruptedBytes)).rejects.toThrowError(
+      FailedToReadData
+    );
+  });
+  test('deserialize fails', () => {
+    // Empty
+    expect(() => {
+      TLV.deserialize(new Uint8Array([]));
+    }).toThrowError(ValueError);
+    // Wrong length
+    expect(() => {
+      TLV.deserialize(new Uint8Array([0, 0, 0, 3, 1, 1]));
+    }).toThrowError(ValueError);
+  });
+});
 
 describe('BaseSMPMessage', () => {
   test('getMPIsfromTLV succeeds', () => {

--- a/test/msgs.test.ts
+++ b/test/msgs.test.ts
@@ -1,10 +1,28 @@
 import * as TCP from 'net';
 import BN from 'bn.js';
 
-import { Byte, Short, Int, MPI, TLV, concatUint8Array } from '../src/msgs';
+import { smpHash } from '../src/hash';
+import {
+  Byte,
+  Short,
+  Int,
+  MPI,
+  TLV,
+  concatUint8Array,
+  BaseSMPMessage,
+  SMPMessage1,
+  SMPMessage2,
+  SMPMessage3,
+  SMPMessage4,
+} from '../src/msgs';
+import { multiplicativeGroupFactory, secretFactory } from '../src/factories';
 import { ValueError, FailedToReadData } from '../src/exceptions';
-
-// TODO: Add tests for `SMPMessage`s
+import { MultiplicativeGroup } from '../src/multiplicativeGroup';
+import {
+  makeProofDiscreteLog,
+  makeProofEqualDiscreteCoordinates,
+  makeProofEqualDiscreteLogs,
+} from '../src/proofs';
 
 describe('Fixed types', () => {
   const types = [Byte, Short, Int];
@@ -169,5 +187,157 @@ describe('TLV', () => {
     expect(() => {
       TLV.deserialize(new Uint8Array([0, 0, 0, 3, 1, 1]));
     }).toThrowError(ValueError);
+  });
+});
+
+describe('BaseSMPMessage', () => {
+  test('getMPIsfromTLV succeeds', () => {
+    const bytes = new Uint8Array([
+      0,
+      0,
+      0,
+      2, // Int: length=2
+      0,
+      0,
+      0,
+      1,
+      1, // 1
+      0,
+      0,
+      0,
+      1,
+      2, // 2
+    ]);
+    const type = new Short(0);
+    const tlv = new TLV(type, bytes);
+    const mpis = BaseSMPMessage.getMPIsfromTLV(type, 2, tlv);
+    expect(mpis[0].value.eqn(1)).toBeTruthy();
+    expect(mpis[1].value.eqn(2)).toBeTruthy();
+  });
+  test('getMPIsfromTLV fails', () => {
+    const bytes = new Uint8Array([
+      0,
+      0,
+      0,
+      2, // Int: length=2
+      0,
+      0,
+      0,
+      1,
+      1, // 1
+      0,
+      0,
+      0,
+      1,
+      2, // 2
+    ]);
+    const type = new Short(0);
+    const tlv = new TLV(type, bytes);
+    const typeAnother = new Short(1);
+    // Wrong type
+    expect(() => {
+      BaseSMPMessage.getMPIsfromTLV(typeAnother, 2, tlv);
+    }).toThrowError(ValueError);
+    // Wrong length
+    expect(() => {
+      BaseSMPMessage.getMPIsfromTLV(type, 3, tlv);
+    }).toThrowError(ValueError);
+    // Invalid MPI format
+    const wrongMPIs = new Uint8Array([
+      0,
+      0,
+      0,
+      1, // length=1
+      0,
+    ]);
+    const wrongTLV = new TLV(type, wrongMPIs);
+    expect(() => {
+      BaseSMPMessage.getMPIsfromTLV(type, 2, wrongTLV);
+    }).toThrowError(ValueError);
+  });
+});
+
+const version = 1;
+
+function hash(...args: BN[]): BN {
+  return smpHash(version, ...args);
+}
+
+describe('SMPMessages', () => {
+  const areSMPMessagesEqual = (
+    a: BaseSMPMessage,
+    b: BaseSMPMessage
+  ): boolean => {
+    if (a.wireValues.length !== b.wireValues.length) {
+      return false;
+    }
+    for (const index in a.wireValues) {
+      const aField = a.wireValues[index];
+      const bField = a.wireValues[index];
+      if (aField instanceof BN && bField instanceof BN) {
+        return aField.eq(bField);
+      } else if (
+        aField instanceof MultiplicativeGroup &&
+        bField instanceof MultiplicativeGroup
+      ) {
+        return aField.equal(bField);
+      } else {
+        return false;
+      }
+    }
+    return true;
+  };
+  const g = multiplicativeGroupFactory();
+  const bn = secretFactory();
+  const q = secretFactory();
+  const proofDiscreteLog = makeProofDiscreteLog(hash, g, bn, bn, q);
+  const proofEDC = makeProofEqualDiscreteCoordinates(
+    hash,
+    g,
+    g,
+    g,
+    bn,
+    bn,
+    bn,
+    bn,
+    q
+  );
+  const proofEDL = makeProofEqualDiscreteLogs(hash, g, g, bn, bn, q);
+
+  test('SMPMessage1 succeeds', () => {
+    const g = multiplicativeGroupFactory();
+    const bn = secretFactory();
+    const q = secretFactory();
+    const proofDiscreteLog = makeProofDiscreteLog(hash, g, bn, bn, q);
+    const msg = new SMPMessage1(g, proofDiscreteLog, g, proofDiscreteLog);
+    expect(
+      areSMPMessagesEqual(msg, SMPMessage1.fromTLV(msg.toTLV(), q))
+    ).toBeTruthy();
+  });
+  test('SMPMessage2 succeeds', () => {
+    const msg = new SMPMessage2(
+      g,
+      proofDiscreteLog,
+      g,
+      proofDiscreteLog,
+      g,
+      g,
+      proofEDC
+    );
+    expect(
+      areSMPMessagesEqual(msg, SMPMessage2.fromTLV(msg.toTLV(), q))
+    ).toBeTruthy();
+  });
+  test('SMPMessage3 succeeds', () => {
+    const msg = new SMPMessage3(g, g, proofEDC, g, proofEDL);
+    expect(
+      areSMPMessagesEqual(msg, SMPMessage3.fromTLV(msg.toTLV(), q))
+    ).toBeTruthy();
+  });
+  test('SMPMessage4 succeeds', () => {
+    const msg = new SMPMessage4(g, proofEDL);
+    expect(
+      areSMPMessagesEqual(msg, SMPMessage4.fromTLV(msg.toTLV(), q))
+    ).toBeTruthy();
   });
 });

--- a/test/msgs.test.ts
+++ b/test/msgs.test.ts
@@ -1,20 +1,21 @@
 import BN from 'bn.js';
 
-import { Byte, Short, Int, MPI, TLV } from '../src/msgs';
+import { Byte, Short, Int, MPI, TLV, concatUint8Array } from '../src/msgs';
+import { ValueError } from '../src/exceptions';
 
 // TODO: Add failure cases
 // TODO: Add tests for `SMPMessage`s
 
 describe('Fixed types', () => {
   const types = [Byte, Short, Int];
-  const expectedSize = [1, 2, 4];
-  const expectedValue = [255, 255, 255];
-  const expectedSerialized = [
-    new Uint8Array([255]),
-    new Uint8Array([0, 255]),
-    new Uint8Array([0, 0, 0, 255]),
-  ];
   test('hardcoded test', () => {
+    const expectedSize = [1, 2, 4];
+    const expectedValue = [255, 255, 255];
+    const expectedSerialized = [
+      new Uint8Array([255]),
+      new Uint8Array([0, 255]),
+      new Uint8Array([0, 0, 0, 255]),
+    ];
     for (const index in types) {
       const Type = types[index];
       const b = new Type(expectedValue[index]);
@@ -26,26 +27,77 @@ describe('Fixed types', () => {
       );
     }
   });
+  test('constructor fails', () => {
+    // Too large
+    for (const index in types) {
+      const Type = types[index];
+      expect(() => {
+        new Type(2 ** (Type.size * 8));
+      }).toThrowError(ValueError);
+    }
+    // Negative
+    for (const Type of types) {
+      expect(() => {
+        new Type(-1);
+      }).toThrowError(ValueError);
+    }
+  });
 });
 
 describe('MPI(variable-length integer)', () => {
-  const values = [
-    new BN(0),
-    new BN(256),
-    new BN(2).pow(new BN(64)).subn(1), // 2**64 - 1
-  ];
-  const expectedSerialized = [
-    new Uint8Array([0, 0, 0, 1, 0]),
-    new Uint8Array([0, 0, 0, 2, 1, 0]),
-    new Uint8Array([0, 0, 0, 8, 255, 255, 255, 255, 255, 255, 255, 255]),
-  ];
   test('hardcoded test', () => {
+    const values = [
+      new BN(0),
+      new BN(256),
+      new BN(2).pow(new BN(64)).subn(1), // 2**64 - 1
+    ];
+    const expectedSerialized = [
+      new Uint8Array([0, 0, 0, 1, 0]),
+      new Uint8Array([0, 0, 0, 2, 1, 0]),
+      new Uint8Array([0, 0, 0, 8, 255, 255, 255, 255, 255, 255, 255, 255]),
+    ];
     for (const index in values) {
       const mpi = new MPI(values[index]);
       const expected = expectedSerialized[index];
       expect(mpi.serialize()).toEqual(expected);
       expect(MPI.deserialize(expected).value.eq(mpi.value));
     }
+  });
+  test('consume', () => {
+    const bytes = concatUint8Array(
+      new Uint8Array([0, 0, 0, 1, 0]),
+      new Uint8Array([0, 0, 0, 2, 1, 0])
+    );
+    const [mpi1, bytesRemaining] = MPI.consume(bytes);
+    expect(mpi1.value.eqn(0)).toBeTruthy();
+    const [mpi2, bytesRemaining2] = MPI.consume(bytesRemaining);
+    expect(mpi2.value.eqn(256)).toBeTruthy();
+    expect(() => {
+      MPI.consume(bytesRemaining2);
+    }).toThrowError(ValueError);
+    // We can consume only the prefix, i.e. [0, 0, 0, 1, 1].
+    const b = new Uint8Array([0, 0, 0, 1, 1, 1]);
+    const [mpi3, bRemaining] = MPI.consume(b);
+    expect(() => {
+      expect(mpi3.value.eqn(1)).toBeTruthy();
+      expect(bRemaining).toEqual(new Uint8Array([1]));
+    });
+  });
+  test('constructor fails', () => {
+    // Negative
+    expect(() => {
+      new MPI(new BN(-1));
+    }).toThrowError(ValueError);
+  });
+  test('deserialize fails', () => {
+    // Empty
+    expect(() => {
+      MPI.deserialize(new Uint8Array([]));
+    }).toThrowError(ValueError);
+    // Wrong length
+    expect(() => {
+      MPI.deserialize(new Uint8Array([0, 0, 0, 1, 1, 1]));
+    }).toThrowError(ValueError);
   });
 });
 

--- a/test/proofs.test.ts
+++ b/test/proofs.test.ts
@@ -11,65 +11,152 @@ import {
 import { defaultConfig } from '../src/config';
 import { secretFactory, multiplicativeGroupFactory } from '../src/factories';
 import { smpHash } from '../src/hash';
+import { MultiplicativeGroup } from '../src/multiplicativeGroup';
 
 const q = defaultConfig.q;
 const version = 1;
+const numTimesRetry = 100;
 
 function hash(...args: BN[]): BN {
   return smpHash(version, ...args);
 }
 
-// TODO: Add failure cases
+function factoryExclude<T>(
+  toBeExcluded: T[],
+  factory: () => T,
+  compareFunc: (a: T, b: T) => boolean
+): T {
+  for (let i = 0; i < numTimesRetry; i++) {
+    let res: T = factory();
+    // Naive workaround to avoid `no-loop-func` when using `Array.find`
+    let found = false;
+    for (const index in toBeExcluded) {
+      if (compareFunc(res, toBeExcluded[index])) {
+        found = true;
+      }
+    }
+    if (!found) {
+      return res;
+    }
+    res = factory();
+  }
+  throw new Error(`failed to create a value excluding ${toBeExcluded}`);
+}
+
+function multiplicativeGroupFactoryExclude(
+  elements: MultiplicativeGroup[]
+): MultiplicativeGroup {
+  return factoryExclude<MultiplicativeGroup>(
+    elements,
+    multiplicativeGroupFactory,
+    (a: MultiplicativeGroup, b: MultiplicativeGroup) => a.equal(b)
+  );
+}
+
 describe('ProofDiscreteLog', () => {
+  const g = multiplicativeGroupFactory();
+  const x = secretFactory();
+  const y = g.exponentiate(x);
+  const r = secretFactory();
+  const pf = makeProofDiscreteLog(hash, g, x, r, q);
+  const gAnother = multiplicativeGroupFactoryExclude([g, y]);
   test('make and verify', () => {
-    const g = multiplicativeGroupFactory();
-    const x = secretFactory();
-    const y = g.exponentiate(x);
-    const r = secretFactory();
-    const pf = makeProofDiscreteLog(hash, g, x, r, q);
     expect(verifyProofDiscreteLog(hash, pf, g, y)).toBeTruthy();
+  });
+  test('given wrong g', () => {
+    expect(verifyProofDiscreteLog(hash, pf, gAnother, y)).toBeFalsy();
+  });
+  test('given wrong y', () => {
+    expect(verifyProofDiscreteLog(hash, pf, g, gAnother)).toBeFalsy();
   });
 });
 
 describe('ProofEqualDiscreteCoordinates', () => {
+  const g0 = multiplicativeGroupFactory();
+  const g1 = multiplicativeGroupFactory();
+  const g2 = multiplicativeGroupFactory();
+  const x0 = secretFactory();
+  const x1 = secretFactory();
+  const r0 = secretFactory();
+  const r1 = secretFactory();
+  const y0 = g0.exponentiate(x0);
+  const y1 = g1.exponentiate(x0).operate(g2.exponentiate(x1));
+  const proof = makeProofEqualDiscreteCoordinates(
+    hash,
+    g0,
+    g1,
+    g2,
+    x0,
+    x1,
+    r0,
+    r1,
+    q
+  );
+  const gAnother = multiplicativeGroupFactoryExclude([g0, g1, g2, y0, y1]);
   test('make and verify', () => {
-    const g0 = multiplicativeGroupFactory();
-    const g1 = multiplicativeGroupFactory();
-    const g2 = multiplicativeGroupFactory();
-    const x0 = secretFactory();
-    const x1 = secretFactory();
-    const r0 = secretFactory();
-    const r1 = secretFactory();
-    const y0 = g0.exponentiate(x0);
-    const y1 = g1.exponentiate(x0).operate(g2.exponentiate(x1));
-    const proof = makeProofEqualDiscreteCoordinates(
-      hash,
-      g0,
-      g1,
-      g2,
-      x0,
-      x1,
-      r0,
-      r1,
-      q
-    );
     expect(
       verifyProofEqualDiscreteCoordinates(hash, g0, g1, g2, y0, y1, proof)
     ).toBeTruthy();
   });
+  test('wrong g0', () => {
+    expect(
+      verifyProofEqualDiscreteCoordinates(hash, gAnother, g1, g2, y0, y1, proof)
+    ).toBeFalsy();
+  });
+  test('wrong g1', () => {
+    expect(
+      verifyProofEqualDiscreteCoordinates(hash, g0, gAnother, g2, y0, y1, proof)
+    ).toBeFalsy();
+  });
+  test('wrong g2', () => {
+    expect(
+      verifyProofEqualDiscreteCoordinates(hash, g0, g1, gAnother, y0, y1, proof)
+    ).toBeFalsy();
+  });
+  test('wrong y0', () => {
+    expect(
+      verifyProofEqualDiscreteCoordinates(hash, g0, g1, g2, gAnother, y1, proof)
+    ).toBeFalsy();
+  });
+  test('wrong y1', () => {
+    expect(
+      verifyProofEqualDiscreteCoordinates(hash, g0, g1, g2, y0, gAnother, proof)
+    ).toBeFalsy();
+  });
 });
 
 describe('ProofEqualDiscreteLogs', () => {
+  const g0 = multiplicativeGroupFactory();
+  const g1 = multiplicativeGroupFactory();
+  const x = secretFactory();
+  const r = secretFactory();
+  const y0 = g0.exponentiate(x);
+  const y1 = g1.exponentiate(x);
+  const proof = makeProofEqualDiscreteLogs(hash, g0, g1, x, r, q);
+  const gAnother = multiplicativeGroupFactoryExclude([g0, g1, y0, y1]);
   test('make and verify', () => {
-    const g0 = multiplicativeGroupFactory();
-    const g1 = multiplicativeGroupFactory();
-    const x = secretFactory();
-    const r = secretFactory();
-    const y0 = g0.exponentiate(x);
-    const y1 = g1.exponentiate(x);
-    const proof = makeProofEqualDiscreteLogs(hash, g0, g1, x, r, q);
     expect(
       verifyProofEqualDiscreteLogs(hash, g0, g1, y0, y1, proof)
     ).toBeTruthy();
+  });
+  test('wrong g0', () => {
+    expect(
+      verifyProofEqualDiscreteLogs(hash, gAnother, g1, y0, y1, proof)
+    ).toBeFalsy();
+  });
+  test('wrong g1', () => {
+    expect(
+      verifyProofEqualDiscreteLogs(hash, g0, gAnother, y0, y1, proof)
+    ).toBeFalsy();
+  });
+  test('wrong y0', () => {
+    expect(
+      verifyProofEqualDiscreteLogs(hash, g0, g1, gAnother, y1, proof)
+    ).toBeFalsy();
+  });
+  test('wrong y1', () => {
+    expect(
+      verifyProofEqualDiscreteLogs(hash, g0, g1, y0, gAnother, proof)
+    ).toBeFalsy();
   });
 });

--- a/test/proofs.test.ts
+++ b/test/proofs.test.ts
@@ -10,12 +10,13 @@ import {
 } from '../src/proofs';
 import { defaultConfig } from '../src/config';
 import { secretFactory, multiplicativeGroupFactory } from '../src/factories';
-import { sha256ToInt } from '../src/hash';
+import { smpHash } from '../src/hash';
 
 const q = defaultConfig.q;
+const version = 1;
 
 function hash(...args: BN[]): BN {
-  return sha256ToInt(defaultConfig.modulusSize, ...args);
+  return smpHash(version, ...args);
 }
 
 // TODO: Add failure cases

--- a/test/proofs.test.ts
+++ b/test/proofs.test.ts
@@ -44,10 +44,10 @@ function factoryExclude<T>(
 }
 
 function multiplicativeGroupFactoryExclude(
-  elements: MultiplicativeGroup[]
+  toBeExcluded: MultiplicativeGroup[]
 ): MultiplicativeGroup {
   return factoryExclude<MultiplicativeGroup>(
-    elements,
+    toBeExcluded,
     multiplicativeGroupFactory,
     (a: MultiplicativeGroup, b: MultiplicativeGroup) => a.equal(b)
   );


### PR DESCRIPTION
1. In [OTR v3 spec](https://otr.cypherpunks.ca/Protocol-v3-4.1.1.html), hash consumes
```
Version (BYTE)
First MPI (MPI)
Second MPI (MPI)
```
This PR change the has name from `sha256ToInt` to `smpHash` and also make the {de}serialization align with the spec.

2. Add tests for messages in `msgs.ts`.

3. Fixes https://github.com/mhchia/js-smp/issues/2.